### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,5 @@ COPY . /usr/src/toadcast/
 WORKDIR /usr/src/toadcast/
 
 RUN mvn clean package
+
+ENTRYPOINT [ "java", "-jar", "./target/toadcast-1-SNAPSHOT-jar-with-dependencies.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM maven
+
+COPY . /usr/src/toadcast/
+WORKDIR /usr/src/toadcast/
+
+RUN mvn clean package

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
 		<repository>
 			<id>maven.jenkins-ci.org</id>
-			<url>http://maven.jenkins-ci.org/releases/</url>
+			<url>http://repo.jenkins-ci.org/releases/</url>
 			<layout>default</layout>
 			<releases>
 				<enabled>true</enabled>


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Maven image, latest tag. More info at https://hub.docker.com/_/maven/

Improved POM's repo URL, previous one was painfully slow.
Just adding files, setting work dir and build. Nothing too fancy.
I'm still figuring out why it fails at runtime for me, but no Java skills. I will file an issue, unless you point me some error with the build. So far, the program runs and listens.

Build:

```
$ docker build -t toadcast .
```

Run:

```
$ docker run --net=host --rm -it toadcast -c "Yourchrome" [other options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --net=host --rm -it pataquets/toadcast -c "Yourchrome" [other options...]
```

Using `--rm` instead of `-d` makes the container not go background and it to be deleted after stop. Should stop by `CTRL+C`'ing it.
Uses the `--net=host` switch to access the host's network stack instead of using container port mappings, for simplicity.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.